### PR TITLE
chore: update PathfindSanctum

### DIFF
--- a/source.json
+++ b/source.json
@@ -189,19 +189,15 @@
       "Description": "Debugging various stuff"
     },
     {
-      "Name": "BetterSanctum",
+      "Name": "PathfindSanctum",
       "OriginalAuthor": "instantsc",
       "Repositories": [
         {
-          "Author": "instantsc",
-          "Name": "BetterSanctum"
-        },
-        {
-          "Author": "ChandlerFerry",
+          "Author": "deafwave",
           "Name": "PathfindSanctum"
         }
       ],
-      "Description": "Improves Sanctum experience. A little"
+      "Description": "Improves Sanctum experience."
     },
     {
       "Name": "HarvestPicker",


### PR DESCRIPTION
1. Removes your repo from the list so users don't get confused
2. Moved mine to my organization to match PoE2
3. Renamed BetterSanctum to PathfindSanctum so it's not confusing